### PR TITLE
chore: Upgrade LibreOffice to version 7.4.2

### DIFF
--- a/Dockerfile.node16-x86_64
+++ b/Dockerfile.node16-x86_64
@@ -14,10 +14,12 @@ RUN yum install \
     yum clean all
 
 RUN set -xo pipefail && \
-    curl "https://ftp.halifax.rwth-aachen.de/tdf/libreoffice/stable/7.4.0/rpm/x86_64/LibreOffice_7.4.0_Linux_x86-64_rpm.tar.gz" | tar -xz
+    curl "https://ftp.halifax.rwth-aachen.de/tdf/libreoffice/stable/7.4.2/rpm/x86_64/LibreOffice_7.4.2_Linux_x86-64_rpm.tar.gz" | tar -xz
 
-RUN cd LibreOffice_7.4.0.3_Linux_x86-64_rpm/RPMS && \
+RUN cd LibreOffice_7.4.2.3_Linux_x86-64_rpm/RPMS && \
     yum install *.rpm -y && \
     rm -rf /var/task/LibreOffice_7.4.0* && \
     cd /opt/libreoffice7.4/ && \
     strip ./**/* || true
+
+ENV HOME=/tmp


### PR DESCRIPTION
fixed: error in transform txt file to pdf
added: ENV `HOME=/tmp` like default lambda dir