### PR TITLE
Libreoffice v24 Upgrade

### DIFF
--- a/Dockerfile.node20-x86_64
+++ b/Dockerfile.node20-x86_64
@@ -9,7 +9,7 @@ RUN dnf install -y xorg-x11-fonts-* libSM.x86_64 libXinerama-devel google-noto-s
 
 RUN cp /lib64/libssl.so.3 /lib64/libssl3.so
 
-RUN mkdir ~/libre && cd ~/libre && curl -s -L https://mirror.quantum5.ca/tdf/libreoffice/stable/24.8.2/rpm/x86_64/LibreOffice_24.8.2_Linux_x86-64_rpm.tar.gz | tar xvz
+RUN mkdir ~/libre && cd ~/libre && curl -s -L https://downloadarchive.documentfoundation.org/libreoffice/old/24.8.3.2/rpm/x86_64/LibreOffice_24.8.3.2_Linux_x86-64_rpm.tar.gz | tar xvz
 
 RUN cd ~/libre/LibreOffice*/RPMS/ && rpm -Uvh *.rpm && rm -fr ~/libre
 

--- a/Dockerfile.node20-x86_64
+++ b/Dockerfile.node20-x86_64
@@ -9,16 +9,32 @@ RUN dnf install -y xorg-x11-fonts-* libSM.x86_64 libXinerama-devel google-noto-s
 
 RUN cp /lib64/libssl.so.3 /lib64/libssl3.so
 
-RUN mkdir ~/libre && cd ~/libre && curl -s -L https://download.documentfoundation.org/libreoffice/stable/7.6.7/rpm/x86_64/LibreOffice_7.6.7_Linux_x86-64_rpm.tar.gz | tar xvz
+RUN mkdir ~/libre && cd ~/libre && curl -s -L https://mirror.quantum5.ca/tdf/libreoffice/stable/24.8.2/rpm/x86_64/LibreOffice_24.8.2_Linux_x86-64_rpm.tar.gz | tar xvz
 
-RUN cd ~/libre/LibreOffice_7.6.7.2_Linux_x86-64_rpm/RPMS/ && rpm -Uvh *.rpm && rm -fr ~/libre
+RUN cd ~/libre/LibreOffice*/RPMS/ && rpm -Uvh *.rpm && rm -fr ~/libre
+
+# Install Amazon Corretto JRE
+RUN curl -L -o corretto.tar.gz https://corretto.aws/downloads/latest/amazon-corretto-11-x64-linux-jdk.tar.gz && \
+    mkdir /usr/local/corretto && \
+    tar -zxf corretto.tar.gz -C /usr/local/corretto --strip-components=1 && \
+    rm corretto.tar.gz
+
+# Set JAVA_HOME and update PATH
+ENV JAVA_HOME=/usr/local/corretto
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+
+# Verify the installation (optional)
+RUN java -version
+
+RUN microdnf install -y libxslt \
+    && microdnf clean all
 
 ENV HOME=/tmp
 
 # Trigger dummy run to generate bootstrap files to improve cold start performance
 RUN touch /tmp/test.txt \
     && cd /tmp \
-    && libreoffice7.6 --headless --invisible --nodefault --view \
+    && libreoffice24.8 --headless --invisible --nodefault --view \
         --nolockcheck --nologo --norestore --convert-to pdf \
-        --outdir /tmp /tmp/test.txt \
-    && rm /tmp/test.*
+        --outdir /tmp /tmp/test.txt 


### PR DESCRIPTION
I started the process of upgrading to Libreoffice v24, starting with the node20 image. I had to include the JRE through Corretto to get it working. Open to anyone's help finding a more efficient way to satisfy the requirements. 

Anyhow, this seems to be working via an updated [aws-lambda-libreoffice](https://github.com/baselinecapital/aws-lambda-libreoffice/commit/c36a2570a0306a4caffda70c092cfd0b178982e4). Feedback welcome