### PR TITLE
Update Dockerfile to use LibreOffice 25.2.4 and adjust package instal…

### DIFF
--- a/Dockerfile.node20-x86_64
+++ b/Dockerfile.node20-x86_64
@@ -1,24 +1,25 @@
-FROM public.ecr.aws/lambda/nodejs:20-x86_64
+FROM --platform=linux/amd64 public.ecr.aws/lambda/nodejs:20-x86_64
 
 ENV PATH=/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin
 
 # Configure linker to correctly point to libraries
 ENV LD_LIBRARY_PATH="/usr/lib:/usr/lib64"
 RUN dnf install -y xorg-x11-fonts-* libSM.x86_64 libXinerama-devel google-noto-sans-cjk-fonts binutils tar gzip xz \
-                    openssl nss-tools dbus-libs cups-libs && dnf clean all
+                    openssl nss-tools dbus-libs cups-libs libxslt && dnf clean all
 
 RUN cp /lib64/libssl.so.3 /lib64/libssl3.so
 
-RUN mkdir ~/libre && cd ~/libre && curl -s -L https://download.documentfoundation.org/libreoffice/stable/7.6.7/rpm/x86_64/LibreOffice_7.6.7_Linux_x86-64_rpm.tar.gz | tar xvz
+RUN mkdir ~/libre && cd ~/libre && curl -s -L https://download.documentfoundation.org/libreoffice/stable/25.2.4/rpm/x86_64/LibreOffice_25.2.4_Linux_x86-64_rpm.tar.gz | tar xvz
 
-RUN cd ~/libre/LibreOffice_7.6.7.2_Linux_x86-64_rpm/RPMS/ && rpm -Uvh *.rpm && rm -fr ~/libre
+# install the rpm packages
+RUN cd ~/libre/LibreOffice_25.2.4.3_Linux_x86-64_rpm/RPMS/ && rpm -Uvh *.rpm && rm -fr ~/libre
 
 ENV HOME=/tmp
 
 # Trigger dummy run to generate bootstrap files to improve cold start performance
 RUN touch /tmp/test.txt \
     && cd /tmp \
-    && libreoffice7.6 --headless --invisible --nodefault --view \
+    && /opt/libreoffice25.2/program/soffice --headless --invisible --nodefault --view \
         --nolockcheck --nologo --norestore --convert-to pdf \
         --outdir /tmp /tmp/test.txt \
     && rm /tmp/test.*


### PR DESCRIPTION
…lations

Changed the LibreOffice version from 7.6.7 to 25.2.4 and updated the corresponding installation commands. Added libxslt to the package installation list and modified the command to trigger the LibreOffice headless operation.